### PR TITLE
Upgrade bufferutil to v3.0.4 to support Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
-    "bufferutil": "3.0.3",
+    "bufferutil": "3.0.4",
     "concurrently": "^3.5.1",
     "cross-env": "5.1.3",
     "downshift": "1.28.5",


### PR DESCRIPTION
Cloned this to try out the app on Windows, build was failing because I was running Node >v10.

As per https://github.com/websockets/bufferutil/issues/95 upgrading the library to 3.0.4 fixes this issue, and the app will successfully build and run on Windows.